### PR TITLE
Parse Opensea transactions

### DIFF
--- a/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
+++ b/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
@@ -103,9 +103,10 @@
             }
         },
         "cancelOrder_": {
-            "action": "canceled bid",
+            "action": "canceled a bid",
+            "keywords": {},
             "exampleDescriptionTemplate": "{userName} {action} on {contractName}",
-            "exampleDescription": "ammaralinur.eth canceled bid on OpenSea"
+            "exampleDescription": "ammaralinur.eth canceled a bid on OpenSea"
         },
         "atomicMatch_": {
             "action": "bought",

--- a/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
+++ b/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
@@ -64,16 +64,19 @@
             }
         },
         "incrementNonce": {
-            "action": "______TODO______",
-            "exampleDescriptionTemplate": "______TODO______",
-            "exampleDescription": "______TODO______",
+            "action": "incremented nonce",
             "keywords": {
-                "__EXAMPLE_KEYWORD__": {
-                    "key": "______TODO______",
-                    "filters": {},
-                    "defaultValue": "______TODO______"
+                "nonce": {
+                    "key": "newNonce",
+                    "filters": {
+                        "eventName": "NonceIncremented",
+                        "maker": "{userAddress}"
+                    },
+                    "defaultValue": "??"
                 }
-            }
+            },
+            "exampleDescriptionTemplate": "{contractName} {action} of {userName} to {nonce}, invalidating all orders that weren't signed with the original nonce.",
+            "exampleDescription": "ammar.eth incremented nonce to 77"
         },
         "renounceOwnership": {
             "action": "______TODO______",
@@ -100,16 +103,14 @@
             }
         },
         "cancelOrder_": {
-            "action": "______TODO______",
-            "exampleDescriptionTemplate": "______TODO______",
-            "exampleDescription": "______TODO______",
+            "action": "canceled order",
             "keywords": {
-                "__EXAMPLE_KEYWORD__": {
-                    "key": "______TODO______",
-                    "filters": {},
-                    "defaultValue": "______TODO______"
+                "NFT": {
+                    "defaultValue": "an unknown NFT"
                 }
-            }
+            },
+            "exampleDescriptionTemplate": "{userName} {action} for {NFT} on {contractName}",
+            "exampleDescription": "ammaralinur.eth canceled order for SmallBrosNFT on OpenSea"
         },
         "atomicMatch_": {
             "action": "bought",

--- a/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
+++ b/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
@@ -64,7 +64,7 @@
             }
         },
         "incrementNonce": {
-            "action": "incremented nonce",
+            "action": "canceled one or more listings",
             "keywords": {
                 "nonce": {
                     "key": "newNonce",
@@ -75,7 +75,7 @@
                     "defaultValue": "??"
                 }
             },
-            "exampleDescriptionTemplate": "{contractName} {action} of {userName} to {nonce}, invalidating all orders that weren't signed with the original nonce.",
+            "exampleDescriptionTemplate": "{userName} {action} on {contractName} by incrementing nonce to {nonce}.",
             "exampleDescription": "ammar.eth incremented nonce to 77"
         },
         "renounceOwnership": {
@@ -103,14 +103,9 @@
             }
         },
         "cancelOrder_": {
-            "action": "canceled order",
-            "keywords": {
-                "NFT": {
-                    "defaultValue": "an unknown NFT"
-                }
-            },
-            "exampleDescriptionTemplate": "{userName} {action} for {NFT} on {contractName}",
-            "exampleDescription": "ammaralinur.eth canceled order for SmallBrosNFT on OpenSea"
+            "action": "canceled bid",
+            "exampleDescriptionTemplate": "{userName} {action} on {contractName}",
+            "exampleDescription": "ammaralinur.eth canceled bid on OpenSea"
         },
         "atomicMatch_": {
             "action": "bought",

--- a/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
+++ b/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
@@ -76,7 +76,7 @@
                 }
             },
             "exampleDescriptionTemplate": "{userName} {action} on {contractName}.",
-            "exampleDescription": "ammar.eth incremented nonce to 77"
+            "exampleDescription": "ammar.eth canceled one or more listings on Opensea"
         },
         "renounceOwnership": {
             "action": "______TODO______",

--- a/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
+++ b/src/core/contractInterpreters/WyvernExchangeWithBulkCancellations_0x7f26.json
@@ -75,7 +75,7 @@
                     "defaultValue": "??"
                 }
             },
-            "exampleDescriptionTemplate": "{userName} {action} on {contractName} by incrementing nonce to {nonce}.",
+            "exampleDescriptionTemplate": "{userName} {action} on {contractName}.",
             "exampleDescription": "ammar.eth incremented nonce to 77"
         },
         "renounceOwnership": {


### PR DESCRIPTION
Only parsed 3 main transaction types on opensea because all other transaction types rarely happen (only one or two on record on etherscan) if ever (most don't exist on etherscan)